### PR TITLE
Feature/custom lookup func

### DIFF
--- a/dnscache.go
+++ b/dnscache.go
@@ -1,77 +1,86 @@
 package dnscache
+
 // Package dnscache caches DNS lookups
 
 import (
-  "net"
-  "sync"
-  "time"
+	"net"
+	"sync"
+	"time"
 )
 
 type Resolver struct {
-  lock sync.RWMutex
-  cache map[string][]net.IP
+	lock  sync.RWMutex
+	cache map[string][]net.IP
 }
 
 func New(refreshRate time.Duration) *Resolver {
-  resolver := &Resolver {
-    cache: make(map[string][]net.IP, 64),
-  }
-  if refreshRate > 0 {
-    go resolver.autoRefresh(refreshRate)
-  }
-  return resolver
+	resolver := &Resolver{
+		cache: make(map[string][]net.IP, 64),
+	}
+	if refreshRate > 0 {
+		go resolver.autoRefresh(refreshRate)
+	}
+	return resolver
 }
 
 func (r *Resolver) Fetch(address string) ([]net.IP, error) {
-  r.lock.RLock()
-  ips, exists := r.cache[address]
-  r.lock.RUnlock()
-  if exists { return ips, nil }
+	r.lock.RLock()
+	ips, exists := r.cache[address]
+	r.lock.RUnlock()
+	if exists {
+		return ips, nil
+	}
 
-  return r.Lookup(address)
+	return r.Lookup(address)
 }
 
 func (r *Resolver) FetchOne(address string) (net.IP, error) {
-  ips, err := r.Fetch(address)
-  if err != nil || len(ips) == 0 { return nil, err}
-  return ips[0], nil
+	ips, err := r.Fetch(address)
+	if err != nil || len(ips) == 0 {
+		return nil, err
+	}
+	return ips[0], nil
 }
 
 func (r *Resolver) FetchOneString(address string) (string, error) {
-  ip, err := r.FetchOne(address)
-  if err != nil || ip == nil { return "", err }
-  return ip.String(), nil
+	ip, err := r.FetchOne(address)
+	if err != nil || ip == nil {
+		return "", err
+	}
+	return ip.String(), nil
 }
 
 func (r *Resolver) Refresh() {
-  i := 0
-  r.lock.RLock()
-  addresses := make([]string, len(r.cache))
-  for key, _ := range r.cache {
-    addresses[i] = key
-    i++
-  }
-  r.lock.RUnlock()
+	i := 0
+	r.lock.RLock()
+	addresses := make([]string, len(r.cache))
+	for key, _ := range r.cache {
+		addresses[i] = key
+		i++
+	}
+	r.lock.RUnlock()
 
-  for _, address := range addresses {
-    r.Lookup(address)
-    time.Sleep(time.Second * 2)
-  }
+	for _, address := range addresses {
+		r.Lookup(address)
+		time.Sleep(time.Second * 2)
+	}
 }
 
 func (r *Resolver) Lookup(address string) ([]net.IP, error) {
-  ips, err := net.LookupIP(address)
-  if err != nil { return nil, err }
+	ips, err := net.LookupIP(address)
+	if err != nil {
+		return nil, err
+	}
 
-  r.lock.Lock()
-  r.cache[address] = ips
-  r.lock.Unlock()
-  return ips, nil
+	r.lock.Lock()
+	r.cache[address] = ips
+	r.lock.Unlock()
+	return ips, nil
 }
 
 func (r *Resolver) autoRefresh(rate time.Duration) {
-  for {
-    time.Sleep(rate)
-    r.Refresh()
-  }
+	for {
+		time.Sleep(rate)
+		r.Refresh()
+	}
 }

--- a/dnscache.go
+++ b/dnscache.go
@@ -8,9 +8,12 @@ import (
 	"time"
 )
 
+var LookupFunc = net.LookupIP
+
 type Resolver struct {
-	lock  sync.RWMutex
-	cache map[string][]net.IP
+	lock       sync.RWMutex
+	cache      map[string][]net.IP
+	LookupFunc func(host string) ([]net.IP, error)
 }
 
 func New(refreshRate time.Duration) *Resolver {
@@ -67,7 +70,7 @@ func (r *Resolver) Refresh() {
 }
 
 func (r *Resolver) Lookup(address string) ([]net.IP, error) {
-	ips, err := net.LookupIP(address)
+	ips, err := LookupFunc(address)
 	if err != nil {
 		return nil, err
 	}

--- a/dnscache_test.go
+++ b/dnscache_test.go
@@ -1,79 +1,79 @@
 package dnscache
 
 import (
-  "net"
-  "sort"
-  "time"
-  "testing"
+	"net"
+	"sort"
+	"testing"
+	"time"
 )
 
 func TestFetchReturnsAndErrorOnInvalidLookup(t *testing.T) {
-  ips, err := New(0).Lookup("invalid.viki.io")
-  if ips != nil {
-    t.Errorf("Expecting nil ips, got %v", ips)
-  }
-  expected := "lookup invalid.viki.io: no such host"
-  if err.Error() != expected {
-    t.Errorf("Expecting %q error, got %q", expected, err.Error())
-  }
+	ips, err := New(0).Lookup("invalid.viki.io")
+	if ips != nil {
+		t.Errorf("Expecting nil ips, got %v", ips)
+	}
+	expected := "lookup invalid.viki.io: no such host"
+	if err.Error() != expected {
+		t.Errorf("Expecting %q error, got %q", expected, err.Error())
+	}
 }
 
 func TestFetchReturnsAListOfIps(t *testing.T) {
-  ips, _ := New(0).Lookup("dnscache.go.test.viki.io")
-  assertIps(t, ips, []string{"1.123.58.13", "31.85.32.110"})
+	ips, _ := New(0).Lookup("dnscache.go.test.viki.io")
+	assertIps(t, ips, []string{"1.123.58.13", "31.85.32.110"})
 }
 
 func TestCallingLookupAddsTheItemToTheCache(t *testing.T) {
-  r := New(0)
-  r.Lookup("dnscache.go.test.viki.io")
-  assertIps(t, r.cache["dnscache.go.test.viki.io"], []string{"1.123.58.13", "31.85.32.110"})
+	r := New(0)
+	r.Lookup("dnscache.go.test.viki.io")
+	assertIps(t, r.cache["dnscache.go.test.viki.io"], []string{"1.123.58.13", "31.85.32.110"})
 }
 
 func TestFetchLoadsValueFromTheCache(t *testing.T) {
-  r := New(0)
-  r.cache["invalid.viki.io"] = []net.IP{net.ParseIP("1.1.2.3")}
-  ips, _ := r.Fetch("invalid.viki.io")
-  assertIps(t, ips, []string{"1.1.2.3"})
+	r := New(0)
+	r.cache["invalid.viki.io"] = []net.IP{net.ParseIP("1.1.2.3")}
+	ips, _ := r.Fetch("invalid.viki.io")
+	assertIps(t, ips, []string{"1.1.2.3"})
 }
 
 func TestFetchOneLoadsTheFirstValue(t *testing.T) {
-  r := New(0)
-  r.cache["something.viki.io"] = []net.IP{net.ParseIP("1.1.2.3"), net.ParseIP("100.100.102.103")}
-  ip, _ := r.FetchOne("something.viki.io")
-  assertIps(t, []net.IP{ip}, []string{"1.1.2.3"})
+	r := New(0)
+	r.cache["something.viki.io"] = []net.IP{net.ParseIP("1.1.2.3"), net.ParseIP("100.100.102.103")}
+	ip, _ := r.FetchOne("something.viki.io")
+	assertIps(t, []net.IP{ip}, []string{"1.1.2.3"})
 }
 
 func TestFetchOneStringLoadsTheFirstValue(t *testing.T) {
-  r := New(0)
-  r.cache["something.viki.io"] = []net.IP{net.ParseIP("100.100.102.103"), net.ParseIP("100.100.102.104")}
-  ip, _ := r.FetchOneString("something.viki.io")
-  if ip != "100.100.102.103" {
-    t.Errorf("expected 100.100.102.103 but got %v", ip)
-  }
+	r := New(0)
+	r.cache["something.viki.io"] = []net.IP{net.ParseIP("100.100.102.103"), net.ParseIP("100.100.102.104")}
+	ip, _ := r.FetchOneString("something.viki.io")
+	if ip != "100.100.102.103" {
+		t.Errorf("expected 100.100.102.103 but got %v", ip)
+	}
 }
 
 func TestFetchLoadsTheIpAndCachesIt(t *testing.T) {
-  r := New(0)
-  ips, _ := r.Fetch("dnscache.go.test.viki.io")
-  assertIps(t, ips, []string{"1.123.58.13", "31.85.32.110"})
-  assertIps(t, r.cache["dnscache.go.test.viki.io"], []string{"1.123.58.13", "31.85.32.110"})
+	r := New(0)
+	ips, _ := r.Fetch("dnscache.go.test.viki.io")
+	assertIps(t, ips, []string{"1.123.58.13", "31.85.32.110"})
+	assertIps(t, r.cache["dnscache.go.test.viki.io"], []string{"1.123.58.13", "31.85.32.110"})
 }
 
 func TestItReloadsTheIpsAtAGivenInterval(t *testing.T) {
-  r := New(1)
-  r.cache["dnscache.go.test.viki.io"] = nil
-  time.Sleep(time.Second * 2)
-  assertIps(t, r.cache["dnscache.go.test.viki.io"], []string{"1.123.58.13", "31.85.32.110"})
+	r := New(1)
+	r.cache["dnscache.go.test.viki.io"] = nil
+	time.Sleep(time.Second * 2)
+	assertIps(t, r.cache["dnscache.go.test.viki.io"], []string{"1.123.58.13", "31.85.32.110"})
 }
 
 func assertIps(t *testing.T, actuals []net.IP, expected []string) {
-  if len(actuals) != len(expected) {
-    t.Errorf("Expecting %d ips, got %d", len(expected), len(actuals))
-  }
-  sort.Strings(expected)
-  for _, ip := range actuals {
-    if sort.SearchStrings(expected, ip.String()) == -1 {
-      t.Errorf("Got an unexpected ip: %v:", actuals[0])
-    }
-  }
+	if len(actuals) != len(expected) {
+		t.Errorf("Expecting %d ips, got %d", len(expected), len(actuals))
+	}
+	sort.Strings(expected)
+	for _, ip := range actuals {
+		if sort.SearchStrings(expected, ip.String()) == -1 {
+			t.Errorf("Got an unexpected ip: %v:", actuals[0])
+		}
+	}
 }


### PR DESCRIPTION
This PR  enables us option to change `Lookup()` func, so we
don't need to use only the `net.LookupIP()`.
This will also help with tests.
Thanks to use of custom `Lookup()`, we can still make tests with
non-existing domains.
Closes #8 